### PR TITLE
WINDUP-2765 Management of missing artifacts in Central Maven Index

### DIFF
--- a/data-text/pom.xml
+++ b/data-text/pom.xml
@@ -62,6 +62,7 @@
                         </goals>
                         <configuration>
                             <mainClass>org.jboss.windup.maven.nexusindexer.GenerateMetadataFile</mainClass>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
                             <arguments>
                                 <argument>text</argument>
                                 <argument>central</argument>
@@ -79,6 +80,7 @@
                         </goals>
                         <configuration>
                             <mainClass>org.jboss.windup.maven.nexusindexer.GenerateMetadataFile</mainClass>
+                            <cleanupDaemonThreads>false</cleanupDaemonThreads>
                             <arguments>
                                 <argument>text</argument>
                                 <argument>jboss</argument>

--- a/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/ArtifactFilter.java
+++ b/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/ArtifactFilter.java
@@ -120,7 +120,8 @@ public interface ArtifactFilter
             + " source sources src source-release project-src gf-project-src"
             + " test tests test-sources tests-sources test-javadoc tests-javadoc"
             + " maven-archetype maven-plugin"
-            + " bin app bundle image dist distribution assembly resources scripts";
+            + " bin app bundle image dist distribution assembly resources scripts"
+            + " module";
         private final Set<String> SKIPPED_CLASSIFIERS = new HashSet<>(Arrays.asList(SKIPPED.split(" ")));
 
 

--- a/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/SortingLineWriterArtifactVisitor.java
+++ b/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/SortingLineWriterArtifactVisitor.java
@@ -8,6 +8,8 @@ import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
+
+import org.apache.commons.collections4.ListUtils;
 import org.apache.commons.collections4.list.TreeList;
 import org.apache.maven.index.ArtifactInfo;
 
@@ -22,7 +24,9 @@ public class SortingLineWriterArtifactVisitor implements RepositoryIndexManager.
     private final OutputStreamWriter writer;
     private final File outFile;
     // Use a TreeList because it is faster to insert and sort.
-    private final List<String> lines = new TreeList<>();
+    // synchronized to support concurrent multi-threads additions from parallel streams
+    // for managing the issue https://issues.redhat.com/browse/WINDUP-2765
+    private final List<String> lines = ListUtils.synchronizedList(new TreeList<>());
     private final ArtifactFilter filter;
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2765

[UPDATE]
7dc5c43 introduced:

- changed the query to search for artifacts atfer another use case has been identified about artifacts with `pom.sha512` file
- the wider conditions raised a lot the number of artifacts to be managed from ~500 to more than 32K and so it implied some changes to retrieve more quickly the hashes so the parallel streams have been introduced (and accordingly changed the support `TreeList` data structure to become thread-safe)
- refactorted log to be more effective