### PR TITLE
WINDUP-2765 Add README and solve a bug in a edge case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Maven Central Index
+
+Since [OSSRH-60950](https://issues.sonatype.org/browse/OSSRH-60950), `nexus-repository-indexer` provides a way to build a fixed version of the `nexus-maven-repository-index.gz` Maven Central Index (ref. [Central Index](https://maven.apache.org/repository/central-index.html#central-index)) without `module` and `pom.512` files but with the right JAR files inside.  
+The `nexus-maven-repository-index.gz` Maven Central Index can either be downloaded from nightly build or built locally.  
+Check the next paragraphs for both the options.
+
+## Download fixed Maven Central Index  
+
+There's a night build that creates ever day an update version of the `nexus-maven-repository-index.gz` Maven Central Index.  
+From the ["Create fixed Maven Central Index" runs list](https://github.com/windup/nexus-repository-indexer/actions?query=event%3Aschedule+is%3Asuccess+workflow%3A%22Create+fixed+Maven+Central+Index%22) select the latest run.  
+In the details page download the `nexus-maven-repository-index.gz` from the `Artifacts` section.
+
+## Create a fixed Maven Central Index  
+
+To build the index locally on your host, follow the following steps:
+
+1. clone this repo  
+`$ git clone https://github.com/windup/nexus-repository-indexer.git`
+1. move into the `nexus-repository-indexer` folder  
+`$ cd nexus-repository-indexer`
+1. install the parent POM  
+`$ mvn -N install`
+1. install the `indexer` module  
+`$ mvn -f indexer/pom.xml install`
+1. build the index  
+`$ mvn -f data-text/pom.xml package -DskipTests -P update-central-index`

--- a/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/UpdateNexusIndex.java
+++ b/indexer/src/main/java/org/jboss/windup/maven/nexusindexer/UpdateNexusIndex.java
@@ -30,15 +30,8 @@ public class UpdateNexusIndex
 
         DependencyRepository repository = new DependencyRepository(repositoryId, repositoryUrl);
 
-        if (!RepositoryIndexManager.metadataExists(repository, outputDir))
-        {
-            log.info("Generating metadata file: [" + RepositoryIndexManager.getMetadataFile(repository, outputDir) + "]");
-            RepositoryIndexManager.updateNexusIndex(repository, indexDir, outputDir);
-        }
-        else
-        {
-            log.info("Metadata file already exists, not generating: [" + RepositoryIndexManager.getMetadataFile(repository, outputDir) + "]");
-        }
+        log.info(String.format("Generating index file: [%s]", outputDir));
+        RepositoryIndexManager.updateNexusIndex(repository, indexDir, outputDir);
     }
 
 
@@ -50,7 +43,7 @@ public class UpdateNexusIndex
         System.err.println("  Parameters:");
         System.err.println("    <repoId>           ID of the repository; used for generated file names.");
         System.err.println("    <repoUrl>          URL of the repository.");
-        System.err.println("    <outputDirectory>  Where to put the created mapping files.");
-        System.err.println("    <indexDirectory>   Where to store the repository index data files.");
+        System.err.println("    <outputDirectory>  Where to put the created index.");
+        System.err.println("    <indexDirectory>   Where to store the temporary Lucene index data files.");
     }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2765

To check the rendered README, refer to https://github.com/mrizzi/nexus-repository-indexer/blob/WINDUP-2765-readme/README.md

The bug fixed in `UpdateNexusIndex.java` was affecting only hosts that both build MTA's index and the Maven Central one, that means no host in the world other than mine.